### PR TITLE
#3: Airflow job for pre-caching frequently visited web map routes

### DIFF
--- a/map/scripts/precache.sh
+++ b/map/scripts/precache.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+bash << 'EOF'
+SUBDOMAIN=prod-k8s
+request(){
+    for(( i=$1; i<=$2; i++));
+    do
+        url="http://treetracker-tile-server.tile-server.svc.cluster.local/${i}/1/1.png"
+        if [ ! -z $3 ];
+        then
+        url="${url}?$3"
+        fi
+        echo $url
+        curl -s -o /dev/null $url && echo "Done at `date`"
+    done
+}
+request 2 15
+request 2 15 map_name=freetown
+request 2 15 map_name=TheHaitiTreeProject
+request 2 15 map_name=addis
+request 2 15 map_name=echo
+request 2 15 map_name=fairtree
+request 2 15 map_name=SustainablyRun
+request 2 15 map_name=KijaniForestry
+request 2 15 wallet=SustainablyRun
+request 2 15 wallet=FreetownCityCouncil
+request 2 15 wallet=JonasPhilanthropiesFairtreeSamburu
+request 2 15 wallet=TheHaitiTreeProject
+request 2 15 wallet=Greenstand
+request 2 15 wallet=SGI.OPT
+request 2 15 wallet=forestmatic-storage
+request 2 15 wallet=usa-river-mali-hai-club
+request 2 15 wallet=Greensteps
+request 2 15 wallet=forestmatic
+request 2 15 wallet=FinorX
+request 2 15 userid=5
+request 2 15 userid=3703
+request 2 15 userid=1073
+request 2 15 userid=2367
+request 2 15 userid=1301
+request 2 15 userid=1060
+request 2 15 userid=2415
+request 2 15 userid=1108
+request 2 15 userid=1155
+request 2 15 userid=1483
+request 2 15 userid=2368
+request 2 15 userid=1953
+request 2 15 userid=1670
+request 2 15 userid=3747
+EOF
+exit 0

--- a/map/tile-pre-cache.py
+++ b/map/tile-pre-cache.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': days_ago(2),
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 0
+}
+
+dag = DAG(
+    'tile-pre-request-container',
+    default_args=default_args,
+    schedule_interval='*/5 * * * *',
+    description='cURLs specific zoom levels and organization maps to refresh cache storage for most visited map views'
+)
+
+t1 = BashOperator(
+    task_id='tile-pre-request-container',
+    bash_command='./scripts/precache.sh',
+    dag=dag
+)


### PR DESCRIPTION
#3 

Developed in Docker Container running Python3 and Ubuntu.

When running `airflow tasks test tile-pre-request-container tile-pre-request-container 2020-12-31`, DAG is run and correct routes are curled and logged to console. 

Output from dashboard, after running `airflow webserver --port 8080` and `airflow scheduler`:
![image](https://user-images.githubusercontent.com/23002786/147891877-923c14d4-58ad-48ae-a612-8d37d13dac39.png)

Job runs every 5 mins and since scheduled start is `days_ago(2)`, several jobs are being run to catch up on missed jobs. 