### PR TITLE
fixed problem with SQL query giving wrong column order and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For access credentials to the dev Airflow and dev or prod readonly postgreSQL da
 
 - Fork this repo.
 - Clone the fork to your local system.
-	- git clone git@github.com:{your github profile name}/treetracker-infrastructure.git
+	- git clone git@github.com:{your github profile name}/treetracker-airflow-dags.git
 - Make a new branch.
 - Make and test your changes on your local Airflow.
 - Git add, commit, and push the changes back to your repo.


### PR DESCRIPTION
Fixed: #188 
problem was with this line of code:

        select cast(top_countries_cte.planted as bigint), region_cte.id region_id, top_countries_cte.name, region_cte.centroid
